### PR TITLE
rotate the char, no turn on move behind, etc

### DIFF
--- a/src/app/game/mod.rs
+++ b/src/app/game/mod.rs
@@ -82,6 +82,7 @@ impl Plugin for GamePlugin {
             PhysicsSchedule,
             (MovementSystemSet, GravitySystemSet, FrictionSystemSet)
                 .chain()
+                // I'd preferably like this to run before PhysicsStep::Prepare
                 .before(PhysicsStepSet::BroadPhase),
         );
     }
@@ -222,9 +223,12 @@ fn setup_level_gen(
             ),
         ))
         .with_children(|parent| {
+            let mut transform = Transform::from_xyz(0.0, -0.35, 0.0).with_scale(Vec3::splat(0.3));
+            transform.rotate_y(std::f32::consts::PI);
+
             parent.spawn(SceneBundle {
                 scene: astronaut,
-                transform: Transform::from_xyz(0.0, -0.35, 0.0).with_scale(Vec3::splat(0.3)),
+                transform,
                 ..default()
             });
         });


### PR DESCRIPTION
Fix several bugs with the character not turning in the correct direction. I also, removed my conversions for forward, left, etc by just inverting the model directly instead lol.

This also accounts for the character going directly backwards and we won't try to align our front with that direction.