### PR TITLE
remove incorrect todo and make a constant out of jump height

### DIFF
--- a/src/app/game/movement.rs
+++ b/src/app/game/movement.rs
@@ -107,6 +107,8 @@ pub fn movement(
     }
 }
 
+const JUMP_STRENGTH: f32 = 16.0;
+
 pub fn jump(
     keyboard_input: Res<Input<KeyCode>>,
     mut players: Query<(&mut ExternalImpulse, &ShapeHits, &GravityBound), With<Player>>,
@@ -131,9 +133,7 @@ pub fn jump(
         let gravity_up = -gravity_force.normalize();
 
         if keyboard_input.just_pressed(KeyCode::Space) {
-            // TODO: The amount of impulse should be inversely proportional to the
-            // gravity force
-            external_impulse.apply_impulse(gravity_up * 16.0);
+            external_impulse.apply_impulse(gravity_up * JUMP_STRENGTH);
         }
     }
 }


### PR DESCRIPTION
AI: In a typical game physics scenario, when a player jumps, they apply a constant force or impulse to themselves. The height they reach and the time they spend in the air is then determined by the gravitational force acting on them.

In a world with stronger gravity, the same jump impulse would result in a shorter jump height and a quicker return to the ground. Conversely, in a world with weaker gravity, the same jump impulse would result in a higher jump and a longer time in the air.